### PR TITLE
Parameterised filepath inputs for probe_finder. Added support for n-many files to be run through the  logic for comparison and filtering

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -4,3 +4,7 @@ class BadConfigFormatException(Exception):
 
 class IncompleteArgsException(Exception):
     pass
+
+
+class InvalidPathException(Exception):
+    pass

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ def parse_input_file(filepath):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", "--file",
-                        help="File containing genome segment defintitions",
+                        help="File containing genome segment definitions",
                         type=str,
                         required=True),
     parser.add_argument("-res", "--range_expansion_size",

--- a/src/probe_finder.py
+++ b/src/probe_finder.py
@@ -1,11 +1,11 @@
+from exceptions import InvalidPathException, IncompleteArgsException
 from math import ceil
+import argparse
 import os
+import datetime
 
-FASTA_OUTPUT = "output/result.fasta"
-TSV_OUTPUT = "output/result.tsv"
 
-INPUT_FILE_ONE = "/Users/rob/PycharmProjects/ervin/data/first_probe_file.tsv"
-INPUT_FILE_TWO = "/Users/rob/PycharmProjects/ervin/data/second_probe_file.tsv"
+DEFAULT_OUTPUT_DIR = os.path.join(os.getcwd(), "OUTPUT")
 
 
 class ProbeData:
@@ -150,38 +150,61 @@ def is_superset(master, comparitor):
     return master.start >= comparitor.start and master.end <= comparitor.end and master.frame == comparitor.frame
 
 
-def write_to_files(record):
-    with open(FASTA_OUTPUT, "a") as fasta:
-        with open(TSV_OUTPUT, "a") as tsv:
+def write_to_files(output_files, record):
+    (fasta_output, tsv_output) = output_files
+    with open(fasta_output, "a") as fasta:
+        with open(tsv_output, "a") as tsv:
             fasta.write(record.to_fasta())
             tsv.write(record.to_tsv())
 
 
-def set_up_output_files():
-    with open(FASTA_OUTPUT, "w"):
-        with open(TSV_OUTPUT, "w"):
+def format_timestamp_for_filename():
+    current_timestamp = datetime.datetime.now()
+    return current_timestamp.strftime("%Y-%m-%d_%H:%M:%S")
+
+
+def set_up_output_files(output_dir):
+    if output_dir is None:
+        output_dir = DEFAULT_OUTPUT_DIR
+    if not os.path.isdir(output_dir):
+        if os.path.exists(output_dir):
+            raise InvalidPathException(f"Invalid output path provided: {output_dir}")
+        else:
+            os.makedirs(output_dir)
+    run_time = format_timestamp_for_filename()
+    fasta_output_path = os.path.join(output_dir, f"probe_finder-{run_time}.fasta")
+    tsv_output_path = os.path.join(output_dir, f"probe_finder-{run_time}.tsv")
+    with open(fasta_output_path, "w"):
+        with open(tsv_output_path, "w"):
             pass
+    return fasta_output_path, tsv_output_path
 
 
 def unique_scaffolds(source_one, source_two):
     source_one_uniques = [scaffold for scaffold in source_one.keys() if scaffold not in source_two.keys()]
     source_two_uniques = [scaffold for scaffold in source_two.keys() if scaffold not in source_one.keys()]
-    return_set = set()
+    return_dict = {}
     for unique in source_one_uniques:
-        return_set.update(source_one[unique])
+        return_dict[unique] = source_one[unique]
         del source_one[unique]
     for unique in source_two_uniques:
-        return_set.update(source_two[unique])
+        return_dict[unique] = source_two[unique]
         del source_two[unique]
-    return return_set
+    return return_dict
 
 
-def run():
-    set_up_output_files()
-    first_probe_data = read_probe_records_from_file(INPUT_FILE_ONE)
-    second_probe_data = read_probe_records_from_file(INPUT_FILE_TWO)
+def flatten_results(result_data):
+    result_list = []
+    for _, value in result_data.items():
+        result_list.extend(list(value))
+    return sorted(result_list)
+
+
+def find_probes(first_probe_data, second_probe_data):
+    # first_probe_data = read_probe_records_from_file(input_file_one)
+    # second_probe_data = read_probe_records_from_file(input_file_two)
     # Add any scaffolds which don't appear in the other file automatically
-    output_set = unique_scaffolds(first_probe_data, second_probe_data)
+    output_data = unique_scaffolds(first_probe_data, second_probe_data)
 
     for scaffold, records in first_probe_data.items():
         for record in records:
@@ -192,9 +215,71 @@ def run():
                 elif is_near_neighbour(current_print_candidate, comparitor) \
                         or is_range_extension(current_print_candidate, comparitor):
                     current_print_candidate = ProbeData.merge_records(current_print_candidate, comparitor)
-            output_set.add(current_print_candidate)
+            if scaffold not in output_data:
+                output_data[scaffold] = {current_print_candidate}
+            else:
+                output_data[scaffold].add(current_print_candidate)
+    return output_data
 
-    [write_to_files(output) for output in sorted(list(output_set))]
+
+def find_probes_recursively(file_list, tail=None):
+    if tail is None:
+        first_probe_data = read_probe_records_from_file(file_list[0])
+        second_probe_data = read_probe_records_from_file(file_list[1])
+
+        if len(file_list) == 2:
+            return find_probes(first_probe_data, second_probe_data)
+        elif len(file_list) < 2:
+            return find_probes_recursively(file_list[2:], tail=find_probes(first_probe_data, second_probe_data))
+    else:
+        probe_data = read_probe_records_from_file(file_list[0])
+
+        if len(file_list) == 1:
+            return find_probes(tail, probe_data)
+        else:
+            return find_probes_recursively(file_list[1:], tail=find_probes(tail, probe_data))
+
+
+def read_filenames_from_manifest(manifest):
+    with open(manifest, 'r') as manifest_file:
+        return [line.strip() for line in manifest_file.readlines()]
+
+
+def run():
+    args = parse_args()
+    result = None
+    if args.file_list is not None:
+        input_files = [input_file.name for input_file in args.file_list]
+        if len(input_files) == 1:
+            raise Exception("Uneccessary run with only one file provided.")
+        elif len(input_files) > 1:
+            result = find_probes_recursively(input_files)
+    else:
+        file_list = read_filenames_from_manifest(args.manifest.name)
+        result = find_probes_recursively(file_list)
+
+    if result is not None:
+        result_data = flatten_results(result)
+        output_files = set_up_output_files(args.output_dir)
+        [write_to_files(output_files, output) for output in result_data]
+    else:
+        raise Exception("No results after running probe_finder.")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--output_dir",
+                        help=str,
+                        required=False)
+    file_sourcing = parser.add_mutually_exclusive_group(required=True)
+    file_sourcing.add_argument("-f", "--file_list",
+                               help="Input file list",
+                               type=argparse.FileType('r'),
+                               nargs='*')
+    file_sourcing.add_argument("-m", "--manifest",
+                               help="Filepath for a manifest file containing a list of input files",
+                               type=argparse.FileType('r')),
+    return parser.parse_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rather than operating strictly on a pair of files named within the source code (requiring manual editing of the script in order to run) the software now supports being supplied with n-many files, supplied by the user either one by one via the commandline or supplied in the form of a manifest file, again named via command line argument.

The output location is now also supplyable via a command line argument, but will default if not supplied to a folder named `OUTPUT` within the current working directory