### PR TITLE
Fix for ridiculous OSX behaviour of converting colons to slashes when saving a filename and therefore impeding the ability to subsequently use any such filename from the commandline

### DIFF
--- a/src/ervin_utils.py
+++ b/src/ervin_utils.py
@@ -3,4 +3,4 @@ import datetime
 
 def format_timestamp_for_filename():
     current_timestamp = datetime.datetime.now()
-    return current_timestamp.strftime("%Y-%m-%d_%H:%M:%S")
+    return current_timestamp.strftime("%Y-%m-%d_%H-%M-%S")


### PR DESCRIPTION
So apparently due to legacy reasons in which filepaths were designated using `:` rather than `/`, OS X will (unpredictably) convert one to the other, and therefore make using the generated filenames awkward.

Substituting the colon in the filename's timestamp for a hyphen to mitigate this behaviour
