### PR TITLE
Bugfix: Incorrect comparison operator resulting in failed runs

### DIFF
--- a/src/probe_finder.py
+++ b/src/probe_finder.py
@@ -96,7 +96,7 @@ def find_probes_recursively(file_list, tail=None):
 
         if len(file_list) == 2:
             return find_probes(first_probe_data, second_probe_data)
-        elif len(file_list) < 2:
+        elif len(file_list) > 2:
             return find_probes_recursively(file_list[2:], tail=find_probes(first_probe_data, second_probe_data))
     else:
         probe_data = read_probe_records_from_file(file_list[0])


### PR DESCRIPTION
When performing the recursive `find_probes` call, the branching logic checked for `len(file_list) < 2` when it should have been `len(file_list) > 2`