### PR TITLE
Improved summary file formatting, removed redundant requirements

### DIFF
--- a/ervin/virus_blaster.py
+++ b/ervin/virus_blaster.py
@@ -170,7 +170,7 @@ def viruses_to_total_found(file_list):
     virus_to_count = {}
     for filepath in file_list:
         row_count = total_result_records([filepath])
-        virus_name = str(filepath).replace(".fasta", "").split("/")[-1]
+        virus_name = filepath.stem[:-20]  # Trim the timestamp from the filename
         virus_to_count[virus_name] = row_count // 2
     return virus_to_count
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 biopython==1.73
-numpy==1.16.1
 progressbar2==3.39.3
 nose==1.3.7
 mock==3.0.5

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as readme:
 
 setuptools.setup(
     name="ervin",
-    version="0.0.5",
+    version="0.0.6",
     description="ERVin is a collection of tools developed to assist "
                 "in discovering ERV sequences within genomic data",
     long_description=long_desc,
@@ -17,15 +17,11 @@ setuptools.setup(
     },
     licence="GPL-3.0-or-later",
     url="https://github.com/strongles/ervin",
-    download_url="https://github.com/strongles/ervin/archive/0.0.5.tar.gz",
+    download_url="https://github.com/strongles/ervin/archive/0.0.6.tar.gz",
     packages=setuptools.find_packages(),
     install_requires=[
             "biopython==1.73",
-            "numpy==1.16.1",
             "progressbar2==3.39.3",
-            "nose==1.3.7",
-            "mock==3.0.5",
-            "flake8==3.7.7",
             "ftputil==3.4"
     ],
     classifiers=[

--- a/setup_generate.py
+++ b/setup_generate.py
@@ -8,6 +8,11 @@ NEWLINE = '\n'
 BIG_INDENT = ' ' * 12
 SMALL_INDENT = ' ' * 4
 SEPARATOR = f",{NEWLINE}{BIG_INDENT}"
+TEST_LIBS = [
+    "mock",
+    "nose",
+    "flake8"
+]
 SETUP_CONTENT = """import setuptools
 
 with open("README.md") as readme:
@@ -51,7 +56,9 @@ def get_current_git_tag():
 
 def get_requirements():
     with open("requirements.txt") as requires:
-        require_list = [f'"{line.strip()}"' for line in requires.readlines()]
+        require_list = [f'"{line.strip()}"'
+                        for line in requires.readlines()
+                        if not any(lib in line for lib in TEST_LIBS)]
     return f"[{NEWLINE}{BIG_INDENT}{SEPARATOR.join(require_list)}{NEWLINE}{SMALL_INDENT}]"
 
 


### PR DESCRIPTION
Improved the way in which the virus name is pulled from the categorised virus filenames (no need to manually parse strings when `pathlib` gived you the stem in one call) as well as stripping out the run timestamp.
`numpy` is required by `biopython` and is not a direct dependency of `ervin`, therefore has been removed from `requirements.txt`
 `setup_generator.py` has been improved so as to exclude testing libraries from `install_requires`. Bumped version number.